### PR TITLE
Remove test plan in favor of test end

### DIFF
--- a/test/create-redux-state-container.test.ts
+++ b/test/create-redux-state-container.test.ts
@@ -3,7 +3,6 @@ import * as redux from 'redux';
 import { createReduxStateContainer, Updater } from '../src/';
 
 test('createReduxStateContainer', (t) => {
-  t.plan(2);
 
   class ProfAction<T> implements redux.Action {
     public type = 'PROF_ACTION';

--- a/test/simple-state-container.test.ts
+++ b/test/simple-state-container.test.ts
@@ -3,7 +3,6 @@ import { SimpleStateContainer } from '../src/';
 import { Updater } from '../src/';
 
 test('SimpleStateContainer', (t) => {
-  t.plan(2);
 
   const state = { number: 1, foo: { bar: { baz: 1 } } };
   const simpleState = new SimpleStateContainer(state);

--- a/test/use-profunctor.test.ts
+++ b/test/use-profunctor.test.ts
@@ -8,7 +8,6 @@ import {
 } from '../lib/commonjs';
 
 test('useProfunctor', (t) => {
-  t.plan(6);
 
   const initialState = { number: 0, foo: { bar: 1 } };
   const [testProf, onStateChange] = useProfunctor(


### PR DESCRIPTION
No need to plan the number of tests if you call end().